### PR TITLE
Task 1: Debugging Precision

### DIFF
--- a/src/components/Event.tsx
+++ b/src/components/Event.tsx
@@ -22,6 +22,7 @@ import { type Venue } from './Events';
 interface EventInfoProps {
   event: {
     short_title: string;
+    datetime_local: Date;
     datetime_utc: Date;
     venue: Venue;
     url: string;
@@ -78,7 +79,7 @@ const EventInfo: React.FC<EventInfoProps> = ({ event }) => (
         <StatLabel display="flex">
           <Box as="span">Date</Box>
         </StatLabel>
-        <StatNumber fontSize="xl">{formatDateTime(event.datetime_utc)}</StatNumber>
+        <StatNumber fontSize="xl">{formatDateTime(event.datetime_local)}</StatNumber>
       </Stat>
     </SimpleGrid>
     <Flex>

--- a/src/components/Event.tsx
+++ b/src/components/Event.tsx
@@ -81,7 +81,7 @@ const EventInfo: React.FC<EventInfoProps> = ({ event }) => (
           <Box as="span">Date</Box>
         </StatLabel>
         <Tooltip label={formatDateTime(event.datetime_utc)} hasArrow placement="top">
-          <StatNumber fontSize="xl">{formatDateTime(event.datetime_local)}</StatNumber>
+          <StatNumber fontSize="xl" maxW="fit-content">{formatDateTime(event.datetime_local)}</StatNumber>
         </Tooltip>
       </Stat>
     </SimpleGrid>

--- a/src/components/Event.tsx
+++ b/src/components/Event.tsx
@@ -12,6 +12,7 @@ import {
   Spinner,
   Button,
   Stack,
+  Tooltip,
 } from '@chakra-ui/react';
 import Breadcrumbs from './Breadcrumbs';
 import Error from './Error';
@@ -79,7 +80,9 @@ const EventInfo: React.FC<EventInfoProps> = ({ event }) => (
         <StatLabel display="flex">
           <Box as="span">Date</Box>
         </StatLabel>
-        <StatNumber fontSize="xl">{formatDateTime(event.datetime_local)}</StatNumber>
+        <Tooltip label={formatDateTime(event.datetime_utc)} hasArrow placement="top">
+          <StatNumber fontSize="xl">{formatDateTime(event.datetime_local)}</StatNumber>
+        </Tooltip>
       </Stat>
     </SimpleGrid>
     <Flex>

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -31,6 +31,7 @@ export interface Venue {
 export interface EventProps {
   id: string;
   short_title: string;
+  datetime_local: Date;
   datetime_utc: Date;
   performers: Performers[];
   venue: Venue;
@@ -93,7 +94,7 @@ const EventItem: React.FC<EventItemProps> = ({ event }) => (
           </Text>
         </Box>
         <Text fontSize="sm" fontWeight="bold" color="gray.600" justifySelf={'end'}>
-          {formatDateTime(event.datetime_utc)}
+          {formatDateTime(event.datetime_local)}
         </Text>
       </Stack>
     </CardBody>

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -11,7 +11,8 @@ import {
   Stack,
   Image,
   LinkBox,
-  LinkOverlay 
+  LinkOverlay, 
+  Tooltip
 } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 import Breadcrumbs from './Breadcrumbs';
@@ -93,9 +94,11 @@ const EventItem: React.FC<EventItemProps> = ({ event }) => (
             {event.venue.display_location}
           </Text>
         </Box>
-        <Text fontSize="sm" fontWeight="bold" color="gray.600" justifySelf={'end'}>
-          {formatDateTime(event.datetime_local)}
-        </Text>
+        <Tooltip label={formatDateTime(event.datetime_utc)} hasArrow placement="top-start">
+          <Text fontSize="sm" fontWeight="bold" color="gray.600" justifySelf={'end'}>
+            {formatDateTime(event.datetime_local)}
+          </Text>
+        </Tooltip>
       </Stack>
     </CardBody>
   </LinkBox>

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -11,8 +11,7 @@ import {
   Stack,
   Image,
   LinkBox,
-  LinkOverlay, 
-  Tooltip
+  LinkOverlay 
 } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 import Breadcrumbs from './Breadcrumbs';
@@ -32,7 +31,6 @@ export interface Venue {
 export interface EventProps {
   id: string;
   short_title: string;
-  datetime_local: Date;
   datetime_utc: Date;
   performers: Performers[];
   venue: Venue;
@@ -94,11 +92,9 @@ const EventItem: React.FC<EventItemProps> = ({ event }) => (
             {event.venue.display_location}
           </Text>
         </Box>
-        <Tooltip label={formatDateTime(event.datetime_utc)} hasArrow placement="top-start">
-          <Text fontSize="sm" fontWeight="bold" color="gray.600" justifySelf={'end'}>
-            {formatDateTime(event.datetime_local)}
-          </Text>
-        </Tooltip>
+        <Text fontSize="sm" fontWeight="bold" color="gray.600" justifySelf={'end'}>
+          {formatDateTime(event.datetime_utc)}
+        </Text>
       </Stack>
     </CardBody>
   </LinkBox>


### PR DESCRIPTION
### Description

Previously, the event details page displayed the event datetime using the `datetime_utc` field from the SeatGeek API, meaning the timestamp was shown in the user's local timezone rather than the event's local timezone.

This PR updates the implementation so that:

- The displayed datetime now uses the API's `datetime_local` field, ensuring we show the event time in the event’s local timezone.
- A tooltip has been added using Chakra UI to display the original UTC datetime when hovering over the timestamp.
- Tooltip styling has been adjusted for clarity, including centering and adding an arrow for better visibility.

### Out of Scope Considerations

While working on this, I considered a few additional improvements but kept them out of scope:

1. Consistency in `Events.tsx` – I initially planned to update the `EventItem` component to use the same local-time display and tooltip for consistency. However, since the ticket only referenced the event details page, I decided to leave that for a follow-up.
2. Improved tooltip messaging – I thought about adding more descriptive text inside the tooltip (e.g., "This is the time in your local timezone..."), but excluded it to stay aligned with the ticket requirements.

If we were working in a team environment, I would have clarified both of these points with stakeholders before proceeding.